### PR TITLE
Set version to 0.6.2-fc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CURRENT_DIR := $(CURRENT_DIR:/=)
 
 # Get the project metadata
 GOVERSION := 1.7.4
-VERSION := 0.6.3
+VERSION := 0.6.2-fc
 PROJECT := github.com/hashicorp/envconsul
 OWNER := $(dir $(PROJECT))
 OWNER := $(notdir $(OWNER:/=))


### PR DESCRIPTION
`0.6.1-fc` has been lost to entropy.
This code is actually envconsul `0.6.2` + the `-secret-no-prefix` patch.

`0.6.2` contains a fix for a panic that happens when a secret contains a `nil` value. (https://github.com/hashicorp/envconsul/commit/9ff4804bad7c4ae3484ea139ea99f838b2ee524c)